### PR TITLE
Handle server without WhoAmI and allow to specify ldap auto_bind parameter

### DIFF
--- a/gmsad.conf.sample
+++ b/gmsad.conf.sample
@@ -84,3 +84,10 @@ check_interval = 60
 # # This only applies if gMSA_servicePrincipalNames is absent or
 # # if gMSA_upn_in_keytab is set.
 # # on_upn_rotate_cmd = echo "Do something"
+#
+# # Optional: LDAP client auto bind parameter.
+# # Can be one of: NONE, NO_TLS, TLS_AFTER_BIND, TLS_BEFORE_BIND.
+# # (https://ldap3.readthedocs.io/en/latest/connection.html)
+# # By default this option is set to "NO_TLS"
+# # Note: Seems to requires TLS_AFTER_BIND when working with a SambaAD
+# # ldap_auto_bind = NO_TLS

--- a/gmsad/ldap.py
+++ b/gmsad/ldap.py
@@ -39,7 +39,12 @@ class LDAPConnection:
                 cred_store={'client_keytab': self.config["keytab"]})
         self.connection.start_tls()
 
-        logging.debug("Authenticated as %s", self.connection.extend.standard.who_am_i())
+        try:
+            logging.debug("Authenticated as %s", self.connection.extend.standard.who_am_i())
+        except ldap3.core.exceptions.LDAPExtensionError as e:
+            if str(e) != "extension not in DSA list of supported extensions":
+                raise e
+            logging.debug("Authenticated as ??? (WhoAmI extension is not supported by the ldap server)")
 
     def get_gmsa_attributes(self, attributes: List[str]) -> Any:
         """


### PR DESCRIPTION
SambaAD doesn't provide the WhoAmI operation, which made the gmsad crash at startup, this is now optional (since it seems to be debug informations)

And the for the `auto_bind`, the current `True` was not working for us (on a sambaAD too). I don't really know why but the `AUTO_BIND_TLS_BEFORE_BIND` worked so I made this configurable using a new `ldap_auto_bind` config parameter.

Don't hesitate to mention if I need to update a documentation for the config parameters somewhere.